### PR TITLE
Fixes #5. Selectively modify the appName on OS X.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -52,7 +52,9 @@ module.exports = class AutoLaunch
             @opts.appName = @opts.appName.substr(0, @opts.appName.length - '.exe'.length)
 
         if /darwin/.test process.platform
-            @opts.appName = @opts.appName.substr(0, @opts.appName.length - '.app'.length)
+            # Remove ".app" from the appName if it exists
+            if @opts.appName.indexOf('.app', @opts.appName.length - '.app'.length) isnt -1
+                @opts.appName = @opts.appName.substr(0, @opts.appName.length - '.app'.length)
 
     # enable
     enable: (cb=()=>) =>


### PR DESCRIPTION
The module currently strips the last 4 characters of the appName on OS X, presumably just _assuming_ that it will end with ".app". I have an Electron app whose appName during development is simply "Electron". The module turns it into "Elec" and will not remove the startup item when requested because the name doesn't match.

This change simply checks that the appName ends with ".app" before removing those last 4 characters.

I suspect a similar fix will be required for Windows where the ".exe" is being removed, but I don't have a Windows environment to test any fix I might make.