### PR TITLE
Better error management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-dist

--- a/dist/AutoLaunchLinux.js
+++ b/dist/AutoLaunchLinux.js
@@ -1,0 +1,39 @@
+var fs, mkdirp, untildify;
+
+fs = require('fs');
+
+mkdirp = require('mkdirp');
+
+untildify = require('untildify');
+
+module.exports = {
+  getDir: function(opts) {
+    return untildify("~/.config/autostart/");
+  },
+  getFile: function(opts) {
+    var file;
+    file = this.getDir() + opts.appName + '.desktop';
+    return file;
+  },
+  enable: function(opts, cb) {
+    var data, file;
+    file = this.getFile(opts);
+    data = ['[Desktop Entry]', 'Type=Application', 'Vestion=1.0', 'Name=' + opts.appName, 'Comment=' + opts.appName + ' startup script', 'Exec=' + opts.appPath, 'StartupNotify=false', 'Terminal=false'].join('\n');
+    mkdirp.sync(this.getDir());
+    fs.writeFileSync(file, data);
+    return cb();
+  },
+  disable: function(opts, cb) {
+    var file;
+    file = this.getFile(opts);
+    if (fs.existsSync(file)) {
+      fs.unlinkSync(file);
+    }
+    return cb();
+  },
+  isEnabled: function(opts, cb) {
+    var file;
+    file = this.getFile(opts);
+    return cb(fs.existsSync(file));
+  }
+};

--- a/dist/AutoLaunchMac.js
+++ b/dist/AutoLaunchMac.js
@@ -1,0 +1,36 @@
+var applescript, tellTo;
+
+applescript = require('applescript');
+
+tellTo = 'tell application "System Events" to ';
+
+module.exports = {
+  enable: (function(_this) {
+    return function(opts, cb) {
+      var command, isHidden, properties;
+      isHidden = opts.isHiddenOnLaunch ? 'false' : 'true';
+      properties = "{path:\"" + opts.appPath + "\", hidden:" + isHidden + ", name:\"" + opts.appName + "\"}";
+      command = tellTo + 'make login item at end with properties ' + properties;
+      return applescript.execString(command, cb);
+    };
+  })(this),
+  disable: (function(_this) {
+    return function(opts, cb) {
+      var command;
+      command = tellTo + ("delete login item \"" + opts.appName + "\"");
+      return applescript.execString(command, cb);
+    };
+  })(this),
+  isEnabled: (function(_this) {
+    return function(opts, cb) {
+      var command;
+      command = tellTo + "get the name of every login item";
+      return applescript.execString(command, function(err, loginItems) {
+        if (loginItems == null) {
+          loginItems = '';
+        }
+        return cb(loginItems.indexOf(opts.appName) > -1, err);
+      });
+    };
+  })(this)
+};

--- a/dist/AutoLaunchWindows.js
+++ b/dist/AutoLaunchWindows.js
@@ -1,0 +1,23 @@
+var Winreg, regKey;
+
+Winreg = require('winreg');
+
+regKey = new Winreg({
+  hive: Winreg.HKCU,
+  key: '\\Software\\Microsoft\\Windows\\CurrentVersion\\Run'
+});
+
+module.exports = {
+  regKey: regKey,
+  enable: function(opts, cb) {
+    return regKey.set(opts.appName, Winreg.REG_SZ, "\"" + opts.appPath + "\"", cb);
+  },
+  disable: function(opts, cb) {
+    return regKey.remove(opts.appName, cb);
+  },
+  isEnabled: function(opts, cb) {
+    return regKey.get(opts.appName, function(err, item) {
+      return cb(item != null);
+    });
+  }
+};

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,112 @@
+var AutoLaunch,
+  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
+module.exports = AutoLaunch = (function() {
+
+  /* Public */
+  function AutoLaunch(opts) {
+    this.isEnabled = __bind(this.isEnabled, this);
+    this.disable = __bind(this.disable, this);
+    this.enable = __bind(this.enable, this);
+    this.fixOpts = __bind(this.fixOpts, this);
+    var versions;
+    if (opts.name == null) {
+      throw new Error('You must specify a name');
+    }
+    this.opts = {};
+    this.opts.appName = opts.name;
+    this.opts.isHiddenOnLaunch = opts.isHidden != null ? opts.isHidden : false;
+    versions = typeof process !== "undefined" && process !== null ? process.versions : void 0;
+    if (opts.path != null) {
+      this.opts.appPath = opts.path;
+    } else if ((versions != null) && ((versions.nw != null) || (versions['node-webkit'] != null) || (versions.electron != null))) {
+      this.opts.appPath = process.execPath;
+    } else {
+      throw new Error("You must give a path (this is only auto-detected for NW.js and Electron apps)");
+    }
+    this.fixOpts();
+    this.api = null;
+    if (/^win/.test(process.platform)) {
+      this.api = require('./AutoLaunchWindows');
+    } else if (/darwin/.test(process.platform)) {
+      this.api = require('./AutoLaunchMac');
+    } else if (/linux/.test(process.platform)) {
+      this.api = require('./AutoLaunchLinux');
+    }
+  }
+
+  AutoLaunch.prototype.fixMacExecPath = function(path) {
+    return path.replace(/(^.+?[^\/]+?\.app)\/Contents\/(Frameworks\/((\1|[^\/]+?) Helper)\.app\/Contents\/MacOS\/\3|MacOS\/Electron)/, '$1');
+  };
+
+  AutoLaunch.prototype.removeNwjsLoginItem = function() {
+    return this.api.disable({
+      appName: 'nwjs Helper'
+    }, function() {
+      return null;
+    });
+  };
+
+  AutoLaunch.prototype.fixOpts = function() {
+    var tempPath;
+    this.opts.appPath = this.opts.appPath.replace(/\/$/, '');
+    if (/darwin/.test(process.platform)) {
+      this.opts.appPath = this.fixMacExecPath(this.opts.appPath);
+    }
+    if (this.opts.appPath.indexOf('/') !== -1) {
+      tempPath = this.opts.appPath.split('/');
+      this.opts.appName = tempPath[tempPath.length - 1];
+    } else if (this.opts.appPath.indexOf('\\') !== -1) {
+      tempPath = this.opts.appPath.split('\\');
+      this.opts.appName = tempPath[tempPath.length - 1];
+      this.opts.appName = this.opts.appName.substr(0, this.opts.appName.length - '.exe'.length);
+    }
+    if (/darwin/.test(process.platform)) {
+      if (this.opts.appName.indexOf('.app', this.opts.appName.length - '.app'.length) !== -1) {
+        return this.opts.appName = this.opts.appName.substr(0, this.opts.appName.length - '.app'.length);
+      }
+    }
+  };
+
+  AutoLaunch.prototype.enable = function(cb) {
+    if (cb == null) {
+      cb = (function(_this) {
+        return function() {};
+      })(this);
+    }
+    if (this.api == null) {
+      return cb(null);
+    }
+    this.api.enable(this.opts, cb);
+    return null;
+  };
+
+  AutoLaunch.prototype.disable = function(cb) {
+    if (cb == null) {
+      cb = (function(_this) {
+        return function() {};
+      })(this);
+    }
+    if (this.api == null) {
+      return cb(null);
+    }
+    this.api.disable(this.opts, cb);
+    return null;
+  };
+
+  AutoLaunch.prototype.isEnabled = function(cb) {
+    if (cb == null) {
+      cb = (function(_this) {
+        return function() {};
+      })(this);
+    }
+    if (this.api == null) {
+      return cb(false);
+    }
+    this.api.isEnabled(this.opts, cb);
+    return null;
+  };
+
+  return AutoLaunch;
+
+})();

--- a/src/AutoLaunchMac.coffee
+++ b/src/AutoLaunchMac.coffee
@@ -23,6 +23,6 @@ module.exports =
         command = tellTo + "get the name of every login item"
 
         applescript.execString command, (err, loginItems) ->
-            return false unless loginItems?
+            loginItems = '' unless loginItems?
 
-            cb(loginItems.indexOf(opts.appName) > -1)
+            cb(loginItems.indexOf(opts.appName) > -1, err)


### PR DESCRIPTION
## What?
After upgrade electron to latest version (0.36.2) the `Autolaunch.isEnabled` function is not detecting loginItems.

To have more info from a developer perspective we want to send `err` in the callback.

## NOTE.
To use our branch in our code we needed to add `dist` folder to the repo. The only important change is on [autoLauchMac file](https://github.com/Teamwork/node-auto-launch/pull/16/files#diff-3cb4ac24dd2f84b466e7af980f600036L26). 

The rest needs to be removed.