### PR TITLE
Fix Electron-app root path detection

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -46,7 +46,9 @@ module.exports = class AutoLaunch
         # Does not match when the three are different
         # Also matches when the path is pointing not to the exectuable in the inner app at all but to the Electron
         # executable in the outer app
-        return path.replace /(^.+?[^\/]+?\.app)\/Contents\/(Frameworks\/((\1|[^\/]+?) Helper)\.app\/Contents\/MacOS\/\3|MacOS\/Electron)/, '$1'
+        path = path.replace /(^.+?[^\/]+?\.app)\/Contents\/(Frameworks\/((\1|[^\/]+?) Helper)\.app\/Contents\/MacOS\/\3|MacOS\/Electron)/, '$1'
+        path = path.replace /\.app\/Contents\/MacOS\/[^\/]*$/, '.app'
+        return path;
 
     removeNwjsLoginItem: ->
         @api.disable {appName: 'nwjs Helper'}, ->

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -48,7 +48,7 @@ module.exports = class AutoLaunch
         # executable in the outer app
         path = path.replace /(^.+?[^\/]+?\.app)\/Contents\/(Frameworks\/((\1|[^\/]+?) Helper)\.app\/Contents\/MacOS\/\3|MacOS\/Electron)/, '$1'
         path = path.replace /\.app\/Contents\/MacOS\/[^\/]*$/, '.app'
-        return path;
+        return path
 
     removeNwjsLoginItem: ->
         @api.disable {appName: 'nwjs Helper'}, ->


### PR DESCRIPTION
I don't know if there's a more elegant way to do this, but our app was detecting the unix executable within the app package using this module when built for distribution.

The added line resolved, so that the app package itself was always selected.
