### PR TITLE
Use the Squirrel Update.exe processStart method to launch the latest version of each app

### DIFF
--- a/src/AutoLaunchWindows.coffee
+++ b/src/AutoLaunchWindows.coffee
@@ -1,3 +1,5 @@
+fs = require 'fs'
+path = require 'path'
 Winreg = require 'winreg'
 Promise = require('es6-promise').Promise
 
@@ -11,8 +13,15 @@ module.exports =
 
     enable: (opts) ->
         new Promise (resolve, reject) ->
+            appPath = opts.appPath
+            arg = ""
+            updateDotExe = path.join(path.dirname(process.execPath), '..', 'update.exe')
+            versions = process?.versions
+            if fs.existsSync(updateDotExe) and versions.electron
+                appPath = updateDotExe
+                arg = " --processStart \"#{path.basename(process.execPath)}\""
             hiddenArg = if opts.isHiddenOnLaunch then ' --hidden' else ''
-            regKey.set opts.appName, Winreg.REG_SZ, "\"#{opts.appPath}\"#{hiddenArg}", (err) ->
+            regKey.set opts.appName, Winreg.REG_SZ, "\"#{appPath}\"#{arg}#{hiddenArg}", (err) ->
                 return reject(err) if err?
                 resolve()
 


### PR DESCRIPTION
This fixes #29 by using the Squirrel `--processStart` trampoline to launch the latest version of the app at all times