### PR TITLE
Fix hiddenArg not working on windows.

### DIFF
--- a/src/AutoLaunchWindows.coffee
+++ b/src/AutoLaunchWindows.coffee
@@ -13,13 +13,14 @@ module.exports =
     enable: (opts) ->
         new Promise (resolve, reject) ->
             appPath = opts.appPath
+            hiddenArg = if opts.isHiddenOnLaunch then ' --hidden' else ''
             arg = ""
             updateDotExe = path.join(path.dirname(process.execPath), '..', 'update.exe')
             versions = process?.versions
             if fs.existsSync(updateDotExe) and versions.electron
                 appPath = updateDotExe
                 arg = " --processStart \"#{path.basename(process.execPath)}\""
-            hiddenArg = if opts.isHiddenOnLaunch then ' --hidden' else ''
+                hiddenArg = if opts.isHiddenOnLaunch then ' --process-start-args "--hidden"' else ''
             regKey.set opts.appName, Winreg.REG_SZ, "\"#{appPath}\"#{arg}#{hiddenArg}", (err) ->
                 return reject(err) if err?
                 resolve()


### PR DESCRIPTION
This should fix the hidden args being ignored when calling squirrel/update.exe.
See: https://github.com/Squirrel/Squirrel.Windows/blob/ee32fb469fc1ace0af6aef7edc389e27b8c063bb/src/Update/Program.cs#L128

Probably closes #31