### PR TITLE
Add option to pass additional arguments

### DIFF
--- a/src/AutoLaunchLinux.coffee
+++ b/src/AutoLaunchLinux.coffee
@@ -9,8 +9,9 @@ module.exports =
     #   :appName - {String}
     #   :appPath - {String}
     #   :isHiddenOnLaunch - {Boolean}
+    #   :addArgs - {Sting}
     # Returns a Promise
-    enable: ({appName, appPath, isHiddenOnLaunch}) ->
+    enable: ({appName, appPath, isHiddenOnLaunch, addArgs}) ->
         hiddenArg = if isHiddenOnLaunch then ' --hidden' else ''
 
         data = """[Desktop Entry]
@@ -18,7 +19,7 @@ module.exports =
                 Version=1.0
                 Name=#{appName}
                 Comment=#{appName}startup script
-                Exec=#{appPath}#{hiddenArg}
+                Exec=#{appPath}#{hiddenArg}#{addArgs}
                 StartupNotify=false
                 Terminal=false"""
 

--- a/src/AutoLaunchLinux.coffee
+++ b/src/AutoLaunchLinux.coffee
@@ -9,17 +9,18 @@ module.exports =
     #   :appName - {String}
     #   :appPath - {String}
     #   :isHiddenOnLaunch - {Boolean}
-    #   :addArgs - {Sting}
+    #   :extraArgs - {Sting}
     # Returns a Promise
-    enable: ({appName, appPath, isHiddenOnLaunch, addArgs}) ->
+    enable: ({appName, appPath, isHiddenOnLaunch, extraArgs}) ->
         hiddenArg = if isHiddenOnLaunch then ' --hidden' else ''
+        args = if extraArgs? then (hiddenArg + ' ' + extraArgs) else hiddenArg
 
         data = """[Desktop Entry]
                 Type=Application
                 Version=1.0
                 Name=#{appName}
-                Comment=#{appName}startup script
-                Exec=#{appPath}#{hiddenArg}#{addArgs}
+                Comment=#{appName} startup script
+                Exec=#{appPath}#{args}
                 StartupNotify=false
                 Terminal=false"""
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -12,12 +12,14 @@ module.exports = class AutoLaunch
     #           to add Login Item
     #   :name - {String}
     #   :path - (Optional) {String}
-    constructor: ({name, isHidden, mac, path}) ->
+    #   :extraArgs - (Optional) {String}
+    constructor: ({name, isHidden, mac, extraArgs, path}) ->
         throw new Error 'You must specify a name' unless name?
 
         @opts =
             appName: name
             isHiddenOnLaunch: if isHidden? then isHidden else false
+            extraArgs: if extraArgs? then extraArgs else ''
             mac: mac ? {}
 
         versions = process?.versions


### PR DESCRIPTION
- Target platforms this affects (Linux, Mac, Mac app store, and or Windows): 

For now, I have only implemented this on Linux. I have to take a better look at how the Windows and Mac functions are structured. Of course, feedback from the Teamwork team is welcome.

- What problem does this solve?

Addresses #46; Sometimes it is nice to pass additional command-line arguments to an app, for instance, Wire Desktop includes a flag `--startup` to start minimized. Now I can add `extraArgs: "--startup", so that the `wire.desktop` file includes the flag.

- Could it break any existing functionality for users?

At least on Linux, I am confident that this shouldn't break any existing functionality.