### PR TITLE
Fix: Linux Exec apppath should be in quotes, it may contains spaces

### DIFF
--- a/src/AutoLaunchLinux.coffee
+++ b/src/AutoLaunchLinux.coffee
@@ -18,7 +18,7 @@ module.exports =
                 Version=1.0
                 Name=#{appName}
                 Comment=#{appName}startup script
-                Exec=#{appPath}#{hiddenArg}
+                Exec="#{appPath}#{hiddenArg}"
                 StartupNotify=false
                 Terminal=false"""
 


### PR DESCRIPTION
- Target platforms this affects (Linux, Mac, Mac app store, and or Windows): Linux
- What problem does this solve? Wraping appPath with quotes
- Could it break any existing functionality for users? No