### PR TITLE
fix readme example and usage to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var AutoLaunch = require('auto-launch');
 
 var minecraftAutoLauncher = new AutoLaunch({
 	name: 'Minecraft',
-	path: '/Applications/Minecraft.app',
+	appPath: '/Applications/Minecraft.app',
 });
 
 minecraftAutoLauncher.enable();
@@ -56,7 +56,7 @@ minecraftAutoLauncher.isEnabled()
 
 The name of your app.
 
-**`options.path`** - String (optional for NW.js and Electron apps)
+**`options.appPath`** - String (optional for NW.js and Electron apps)
 
 The absolute path to your app.
 


### PR DESCRIPTION
<!-- Thanks for contributing. Please fill the following out: -->

- Target platforms this affects (Linux, Mac, Mac app store, and or Windows): All
- What problem does this solve? fix documentation to match code
- Could it break any existing functionality for users? No

---

<!-- Add more information below this line if you like -->

I believe the readme is out of date since the code seems to rely on `appPath` rather than the `path` shown in the readme.