### PR TITLE
Fix linux path quotes

### DIFF
--- a/src/AutoLaunchLinux.coffee
+++ b/src/AutoLaunchLinux.coffee
@@ -17,8 +17,8 @@ module.exports =
                 Type=Application
                 Version=1.0
                 Name=#{appName}
-                Comment=#{appName}startup script
-                Exec=#{appPath}#{hiddenArg}
+                Comment=#{appName} Startup Script
+                Exec="#{appPath}"#{hiddenArg}
                 StartupNotify=false
                 Terminal=false"""
 


### PR DESCRIPTION
- Target platforms this affects (Linux, Mac, Mac app store, and or Windows): 
Linux
- What problem does this solve?
Linux compatibility
- Could it break any existing functionality for users?
No
---
This PR fixes the wrongly quoted path on Linux systems, which makes the module incompatible in situations where the path has any whitespace (or other characters which have to be escaped)