### PR TITLE
Add FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ node-auto-launch
 Auto-launch your app on login.
 
 - :star: Launch any application or executable at startup / login / boot.
-- :star: Supports Linux, Mac (via AppleScript or Launch Agent), and Windows.
+- :star: Supports Linux, FreeBSD, Mac (via AppleScript or Launch Agent), and Windows.
 - :star: Supports [NW.js](http://nwjs.io/) and [Electron](http://electron.atom.io/) (with or without Squirrel; i.e. even if you're using Electron's built-in [`autoUpdater`](http://electron.atom.io/docs/api/auto-updater/) API).
 - :star: Auto-detects your app path for NW.js and Electron apps.
 - :star: Supports NW.js and Electron apps in Windows Store (with some caveats). 
@@ -93,7 +93,7 @@ Returns a Promise which resolves to a Boolean; `true` if your app is set to laun
 
 ## How does it work?
 
-### Linux
+### Linux / FreeBSD
 
 A [Desktop Entry](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) is created; i.e. a `.desktop` file is created in `~/.config/autostart/`.
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -39,7 +39,7 @@ module.exports = class AutoLaunch
             @api = require './AutoLaunchWindows'
         else if /darwin/.test process.platform
             @api = require './AutoLaunchMac'
-        else if /linux/.test process.platform
+        else if (/linux/.test process.platform) or (/freebsd/.test process.platform)
             @api = require './AutoLaunchLinux'
         else
             throw new Error 'Unsupported platform'

--- a/tests/index.coffee
+++ b/tests/index.coffee
@@ -11,7 +11,7 @@ if /^win/.test process.platform
 else if /darwin/.test process.platform
     isMac = true
     executablePath = '/Applications/Calculator.app'
-else if /linux/.test process.platform
+else if (/linux/.test process.platform) or (/freebsd/.test process.platform)
     executablePath = path.resolve path.join './tests/executables', 'hv3-linux-x86'
 
 console.log "Executable being used for tests:", executablePath


### PR DESCRIPTION
FreeBSD can be treated in the same way as Linux for auto launch
applications.

- Target platforms this affects (Linux, Mac, Mac app store, and or Windows): 
FreeBSD

- What problem does this solve?
Support auto launching apps on FreeBSD.

- Could it break any existing functionality for users?
It should not break anyone.

---

"npm test" passed (with updated gulp and updated gulpfile.coffee, but these are not related to this change).