### PR TITLE
Upgrade mkdirp to 0.5.4 to fix minimist security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/4ver/node-auto-launch",
   "dependencies": {
     "applescript": "^1.0.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^0.5.4",
     "path-is-absolute": "^1.0.0",
     "untildify": "^3.0.2",
     "winreg": "1.2.4"


### PR DESCRIPTION
- Target platforms this affects (Linux, Mac, Mac app store, and or Windows): Linux, Mac, Windows
- What problem does this solve? fix minimist security issue
- Could it break any existing functionality for users? No

Minimist security issue details here -> https://snyk.io/vuln/SNYK-JS-MINIMIST-559764