### PR TITLE
Fixing appPath that contains spaces for Linux.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-launch",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Launch node applications or executables at login (Mac, Windows, and Linux)",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -33,6 +33,7 @@ module.exports = class AutoLaunch
             throw new Error 'You must give a path (this is only auto-detected for NW.js and Electron apps)'
 
         @fixOpts()
+        @fixLinuxExecPath()
 
         @api = null
         if /^win/.test process.platform
@@ -75,6 +76,11 @@ module.exports = class AutoLaunch
         path = path.replace /\.app\/Contents\/MacOS\/[^\/]*$/, '.app' unless macOptions.useLaunchAgent
         return path
 
+    fixLinuxExecPath: =>
+        # This is going to escape the spaces in the executable path
+        # Fixing all problems with unescaped paths for Linux
+        if /linux/.test process.platform
+            @opts.appPath = @opts.appPath.replace(/(\s+)/g, '\\$1')
 
     fixOpts: =>
         @opts.appPath = @opts.appPath.replace /\/$/, ''


### PR DESCRIPTION
<!-- Thanks for contributing. Please fill the following out: -->

- Target platforms this affects (Linux, Mac, Mac app store, and or Windows): 
Linux
- What problem does this solve?
This solve issues with executable paths in the desktop entry for Linux that contains spaces.
- Could it break any existing functionality for users?
No.
---

<!-- Add more information below this line if you like -->
